### PR TITLE
chore: expose a method to set the torch mode

### DIFF
--- a/android/src/main/java/com/rncamerakit/RNCameraKitModule.kt
+++ b/android/src/main/java/com/rncamerakit/RNCameraKitModule.kt
@@ -37,4 +37,15 @@ class RNCameraKitModule(private val reactContext: ReactApplicationContext) : Rea
             view.capture(options.toHashMap(), promise)
         }
     }
+
+    @ReactMethod
+    fun setTorchMode( mode: String, viewTag: Int) {
+        val context = reactContext
+        val uiManager = context.getNativeModule(UIManagerModule::class.java)
+        context.runOnUiQueueThread {
+            val view = uiManager?.resolveView(viewTag) as CKCamera
+            view.setTorchMode(mode)
+        }
+
+    }
 }

--- a/ios/ReactNativeCameraKit/CKCamera.h
+++ b/ios/ReactNativeCameraKit/CKCamera.h
@@ -76,6 +76,8 @@ typedef NS_ENUM(NSInteger, CKCameraZoomMode) {
 // api
 - (void)snapStillImage:(NSDictionary*)options success:(CaptureBlock)block onError:(void (^)(NSString*))onError;
 
+- (void)setTorchMode:(AVCaptureTorchMode)torchMode;
+
 + (NSURL*)saveToTmpFolder:(NSData*)data;
 
 @end

--- a/ios/ReactNativeCameraKit/CKCameraManager.m
+++ b/ios/ReactNativeCameraKit/CKCameraManager.m
@@ -44,6 +44,17 @@ RCT_EXPORT_METHOD(capture:(NSDictionary*)options
     }];
 }
 
+RCT_EXPORT_METHOD(setTorchMode:(NSString*)mode) {
+    AVCaptureTorchMode torchMode;
+    if([mode isEqualToString:@"on"]) {
+        torchMode = AVCaptureTorchModeOn;
+    } else {
+        torchMode = AVCaptureTorchModeOff;
+    }
+    
+    [self.camera setTorchMode:torchMode ];
+}
+
 RCT_EXPORT_METHOD(checkDeviceCameraAuthorizationStatus:(RCTPromiseResolveBlock)resolve
                   reject:(__unused RCTPromiseRejectBlock)reject) {
 

--- a/src/Camera.android.tsx
+++ b/src/Camera.android.tsx
@@ -16,6 +16,9 @@ const Camera = React.forwardRef((props: any, ref) => {
       // we must use the general module and tell it what View it's supposed to be using
       return await RNCameraKitModule.capture(options, findNodeHandle(nativeRef.current ?? null));
     },
+    setTorchMode: (mode = "off") => {
+      RNCameraKitModule.setTorchMode(mode, findNodeHandle(nativeRef.current ?? null));
+    },
     requestDeviceCameraAuthorization: () => {
       throw new Error('Not implemented');
     },

--- a/src/Camera.ios.tsx
+++ b/src/Camera.ios.tsx
@@ -14,6 +14,9 @@ const Camera = React.forwardRef((props: any, ref: any) => {
     capture: async () => {
       return await CKCameraManager.capture({});
     },
+    setTorchMode: (mode = "off") => {
+      CKCameraManager.setTorchMode(mode);
+    },
     requestDeviceCameraAuthorization: async () => {
       return await CKCameraManager.checkDeviceCameraAuthorizationStatus();
     },

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export type CameraApi = {
   capture: () => Promise<{ uri: string }>,
+  setTorchMode: (mode: String) => void;
   requestDeviceCameraAuthorization: () => Promise<boolean>,
   checkDeviceCameraAuthorizationStatus: () => Promise<boolean>,
 };


### PR DESCRIPTION
## Summary

This pull request exposes a method to toggle the torch light. The flashMode/torchMode offered by the camera-kit API were not working in both iOS and Android. An open issue is already open regarding this https://github.com/teslamotors/react-native-camera-kit/issues/518. 
This is blocking my team from using react-native-camera-kit. We really need this change to unblock us.

Now, when an app wants to turn on or off the torch light, it can call the setTorchMode and provide a mode (either **on** or **off**)

## How did you test this change?

Tested this change in our app on both Android and iOS using a physical Android device (Motorola) and a physical iPhone 12.

Here is the source code. Basically, just need to call the setTorchMode on the ref instance of the camera.


```
    import React, { useRef, useState } from 'react';
    import {
      Dimensions,
      StyleSheet,
      View,
      TouchableOpacity,
      Text,
    } from 'react-native';
    import { Camera, CameraType } from 'react-native-camera-kit';

    const CameraOverlay = () => {
      const camera = useRef(null);
      const [toggleFlash, setToggleFlash] = useState(false);

      return (
        <View style={[styles.cameraViewContainer]}>
          <View style={[styles.mainContainer]}>
            <Camera
              ref={(ref) => (camera.current = ref)}
              cameraType={CameraType.Back}
              style={styles.cameraStyle}
            />

            <TouchableOpacity
              style={
                toggleFlash
                  ? [styles.flashlightTogglerStyle, styles.flashlightOnStyle]
                  : [styles.flashlightTogglerStyle, styles.flashlightOffStyle]
              }
              onPress={() => {
                camera.current.setTorchMode(!toggleFlash ? 'on' : 'off');
                setToggleFlash((current) => !current);
              }}
              activeOpacity={0.7}
            >
              <Text>Flash Light</Text>
            </TouchableOpacity>
          </View>
        </View>
      );
    };

    const styles = StyleSheet.create({
      mainContainer: {
        flex: 1,
        justifyContent: 'center',
        alignItems: 'center',
      },
      cameraViewContainer: {
        aspectRatio: 1,
        height: '90%',
        borderWidth: 1,
        borderRadius: 20,
        borderColor: 'transparent',
      },
      cameraStyle: {
        width: '100%',
        height: '90%',
        borderRadius: 20,
      },
      camera: {
        flex: 1,
        alignItems: 'center',
        justifyContent: 'center',
        backgroundColor: 'transparent',
        height: Dimensions.get('window').width,
        width: Dimensions.get('window').width,
      },
      flashlightTogglerStyle: {
        position: 'absolute',
        width: 50,
        height: 50,
        top: 10,
        right: 10,
        borderRadius: 23,
        justifyContent: 'center',
        alignItems: 'center',
      },
      flashlightOnStyle: {
        backgroundColor: '#fff',
      },
      flashlightOffStyle: {
        backgroundColor: 'lightgray',
      },
    });

    export default CameraOverlay;
```

Here, I included two videos to demo this change. When the '**Flash Light**' button becomes white, the torch is on. And you can see that the torch light turned on because my table got lighter. When this button becomes gray, the torch is off, and the lights of the phones turns off.



Here is a video that shows the test results on Android:

https://user-images.githubusercontent.com/63681471/216187083-9d1d0917-1a5c-4cf1-848d-8d7fd8ef2c0e.mp4


And this one on an iPhone:



